### PR TITLE
Build scanner.cc in build.rs

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -25,7 +25,6 @@ fn main() {
     // If your language uses an external scanner written in C++,
     // then include this block of code:
 
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +35,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }


### PR DESCRIPTION
This resolves an issue for those using the grammar as a crate where the linker would complain about undefined symbols.